### PR TITLE
Fix error "Files in the public directory are served at the root path."

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 
 @font-face {
   font-family: "Nunito";
-  src: url(/public/nunito.ttf);
+  src: url(/nunito.ttf);
 }
 
 :root{


### PR DESCRIPTION
Fix vite error:

Files in the public directory are served at the root path.
Instead of /public/nunito.ttf, use /nunito.ttf.

<img width="711" alt="image" src="https://github.com/alejoevilches/balance/assets/56631428/076c92b0-18ea-419f-8430-5e1120210bf3">
